### PR TITLE
Support ignoring opt out people

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,11 @@ GEM
       dm-validations (~> 1.2.0)
     data_objects (0.10.17)
       addressable (~> 2.1)
-    database_cleaner (1.7.0)
+    database_cleaner (1.8.5)
+    database_cleaner-core (2.0.1)
+    database_cleaner-sequel (2.0.2)
+      database_cleaner-core (~> 2.0.0)
+      sequel
     dm-aggregates (1.2.0)
       dm-core (~> 1.2.0)
     dm-constraints (1.2.0)
@@ -143,6 +147,7 @@ DEPENDENCIES
   bundler
   byebug
   database_cleaner
+  database_cleaner-sequel
   minitest
   mocha
   simplecov

--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,8 @@ namespace :db do
 
   namespace :schema do
     task :dump do
-      sh "pg_dump -sO #{ENV['DATABASE_URL']} > db/schema.sql"
+      sh "pg_dump --schema-only --no-owner #{ENV['DATABASE_URL']} > db/schema.sql"
+      sh "pg_dump --table migration_info --data-only --no-owner #{ENV['DATABASE_URL']} >> db/schema.sql"
     end
 
     task load: 'db:create' do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 require 'tech404logs'
 
 Rake::TestTask.new(test: ['env:test', 'db:schema:load', :environment]) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'tech404logs'
+require 'tech404logs/tasks/opt_out_user'
 
 Rake::TestTask.new(test: ['env:test', 'db:schema:load', :environment]) do |t|
   t.libs << 'test'
@@ -23,6 +24,13 @@ end
 
 task :reindex => [:environment] do
   Tech404logs.db.execute 'REFRESH MATERIALIZED VIEW searchable_messages'
+end
+
+namespace :user do
+  desc 'Set a users opted_out flag to true and stop recording messages from them'
+  task :optout => [:environment] do
+    Tech404logs::Tasks::OptOutUser.run
+  end
 end
 
 namespace :db do

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :default => :test
 namespace :env do
   task :test do
     ENV['RACK_ENV'] = 'test'
-    ENV['DATABASE_URL'] = ENV['TEST_DATABASE_URL']
+    ENV['DATABASE_URL'] = ENV.fetch('TEST_DATABASE_URL')
   end
 end
 

--- a/db/migrate/006_add_opted_out_to_users.rb
+++ b/db/migrate/006_add_opted_out_to_users.rb
@@ -1,0 +1,9 @@
+migration 6, :add_opted_out_to_users do
+  up do
+    execute 'ALTER TABLE users ADD COLUMN "opted_out" BOOLEAN NOT NULL default false'
+  end
+
+  down do
+    execute 'ALTER TABLE users DROP COLUMN "opted_out"'
+  end
+end

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -62,7 +62,8 @@ CREATE TABLE public.users (
     id character varying(50) NOT NULL,
     name character varying(50),
     real_name character varying(50),
-    image character varying(255)
+    image character varying(255),
+    opted_out boolean DEFAULT false NOT NULL
 );
 
 
@@ -193,6 +194,7 @@ rename_messages_table
 rename_users_table
 add_index_to_messages
 add_fulltext_index_to_messages
+add_opted_out_to_users
 \.
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -164,3 +164,39 @@ CREATE INDEX searchable_messages_tsv ON public.searchable_messages USING gin (ts
 -- PostgreSQL database dump complete
 --
 
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 13.6
+-- Dumped by pg_dump version 13.6
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Data for Name: migration_info; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.migration_info (migration_name) FROM stdin;
+starting_point
+rename_channels_table
+rename_messages_table
+rename_users_table
+add_index_to_messages
+add_fulltext_index_to_messages
+\.
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/lib/tech404logs.rb
+++ b/lib/tech404logs.rb
@@ -16,6 +16,7 @@ require 'tech404logs/channel_mention_filter'
 require 'tech404logs/configuration'
 require 'tech404logs/connection'
 require 'tech404logs/event_handler'
+require 'tech404logs/fake_cache'
 require 'tech404logs/handlers'
 require 'tech404logs/handlers/user_handler'
 require 'tech404logs/handlers/message_handler'
@@ -30,7 +31,11 @@ require 'tech404logs/worker_fork'
 
 module Tech404logs
   def self.cache
-    @cache ||= Cache.new
+    @cache ||= if production?
+      Cache.new
+    else
+      FakeCache.new
+    end
   end
 
   def self.configuration

--- a/lib/tech404logs/fake_cache.rb
+++ b/lib/tech404logs/fake_cache.rb
@@ -1,0 +1,11 @@
+module Tech404logs
+  class FakeCache
+    def initialize
+    end
+
+    def fetch(key, ttl = Tech404logs.configuration.cache_ttl, options = {})
+      yield
+    end
+  end
+end
+

--- a/lib/tech404logs/handlers/message_handler.rb
+++ b/lib/tech404logs/handlers/message_handler.rb
@@ -26,12 +26,12 @@ module Tech404logs
       attr_reader :db, :table, :user_handler
 
       def store(message)
-        db.transaction do 
+        db.transaction do
           table.insert(
             channel_id: message.fetch('channel'),
             user_id: user_handler.handle(message.fetch('user')),
             text: message.fetch('text'),
-            timestamp: Time.at(Float(message.fetch('ts')))
+            timestamp: Time.at(Float(message.fetch('ts')), in: 'utc')
           )
         end
       end

--- a/lib/tech404logs/handlers/user_handler.rb
+++ b/lib/tech404logs/handlers/user_handler.rb
@@ -7,7 +7,7 @@ module Tech404logs
         @table = Sequel::Model.db[:users]
       end
 
-      # Returns a record of the upserted User
+      # Returns the id of the upserted User
       def handle(event_or_id)
         case event_or_id
         when Hash

--- a/lib/tech404logs/handlers/user_handler.rb
+++ b/lib/tech404logs/handlers/user_handler.rb
@@ -3,32 +3,46 @@ module Tech404logs
     class UserHandler
 
       def initialize
+        @db = Sequel::Model.db
         @table = Sequel::Model.db[:users]
       end
 
-      # Returns the id of the upserted User
+      # Returns a record of the upserted User
       def handle(event_or_id)
         case event_or_id
         when Hash
-          table.insert_conflict(target: :id, update: {
-            name: Sequel[:excluded][:name],
-            real_name: Sequel[:excluded][:real_name],
-            image: Sequel[:excluded][:image],
-          }).insert(
-            id: event_or_id.fetch('id'),
-            name: event_or_id.fetch('name'),
-            real_name: event_or_id.fetch('profile').fetch('real_name'),
-            image: event_or_id.fetch('profile').fetch('image_48')
-          )
+          upsert_user(event_or_id)
         when String
           table.insert_ignore.insert(id: event_or_id)
           event_or_id
         end
       end
 
+      def opted_out?(user_id)
+        table.where(id: user_id, opted_out: true).count > 0
+      end
+
       private
 
-      attr_reader :table
+      attr_reader :db, :table
+
+      def upsert_user(event)
+        db.transaction do
+          user_id = event.fetch('id')
+          return user_id if opted_out?(user_id)
+
+          table.insert_conflict(target: :id, update: {
+            name: Sequel[:excluded][:name],
+            real_name: Sequel[:excluded][:real_name],
+            image: Sequel[:excluded][:image],
+          }).insert(
+            id: user_id,
+            name: event.fetch('name'),
+            real_name: event.fetch('profile').fetch('real_name'),
+            image: event.fetch('profile').fetch('image_48')
+          )
+        end
+      end
 
     end
   end

--- a/lib/tech404logs/tasks/opt_out_user.rb
+++ b/lib/tech404logs/tasks/opt_out_user.rb
@@ -1,0 +1,65 @@
+require 'readline'
+require 'pp'
+
+module Tech404logs
+  module Tasks
+    class OptOutUser
+      def self.run
+        new.run
+      end
+
+      def initialize
+        @db = Sequel::Model.db
+        @users = Sequel::Model.db[:users]
+      end
+
+      def run
+        puts "Please enter the user's ID (It looks like U03H0B61B)"
+        user_id = Readline.readline("> ").strip
+
+        db.transaction do
+          if user = find_user(user_id)
+            pp user
+            confirm('Are you sure you want to opt this user out?') do
+              opt_out_user!(user_id)
+              puts 'User has been opted out.'
+            end
+          else
+            puts "That user doesn't exist."
+            confirm("Would you like to create an opted out record of them?") do
+              create_opted_out_stub_user(user_id)
+              puts 'Opted out stub user has been created.'
+            end
+          end
+        end
+      end
+
+      private
+
+      attr_reader :db, :users
+
+      def confirm(prompt)
+        confirmation = Readline.readline("#{prompt} [Y/n] ").strip
+        yield if confirmation =~ /\A[yY]\Z/
+      end
+
+      def create_opted_out_stub_user(user_id)
+        users.insert_conflict(target: :id, update: {
+          opted_out: Sequel[:excluded][:opted_out],
+        }).insert(
+          id: user_id,
+          opted_out: true
+        )
+      end
+
+      def find_user(user_id)
+        users.where(id: user_id).first
+      end
+
+      def opt_out_user!(user_id)
+        users.where(id: user_id).update(opted_out: true)
+      end
+
+    end
+  end
+end

--- a/lib/tech404logs/user.rb
+++ b/lib/tech404logs/user.rb
@@ -9,6 +9,7 @@ module Tech404logs
     property :name, String
     property :real_name, String
     property :image, String, length: 255
+    property :opted_out, Boolean
 
     def self.create_or_update(user)
       first_or_new(id: user.fetch('id')).tap do |record|

--- a/lib/tech404logs/user.rb
+++ b/lib/tech404logs/user.rb
@@ -20,6 +20,8 @@ module Tech404logs
     end
 
     def self.store(user_or_id)
+      warn '[DEPRECATION] User.store is deprecated. All user updates should go through UserHandler'
+
       case user_or_id
       when Hash
         create_or_update(user_or_id)

--- a/tech404-index.gemspec
+++ b/tech404-index.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'database_cleaner'
+  spec.add_development_dependency 'database_cleaner-sequel'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'simplecov'

--- a/test/functional/handlers/message_handler_test.rb
+++ b/test/functional/handlers/message_handler_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 describe Handlers::MessageHandler do
   subject { Handlers::MessageHandler.new }
+  let(:messages) { Sequel::Model.db[:messages] }
+  let(:users) { Sequel::Model.db[:users] }
 
   describe '#handle' do
     let(:event) { {
@@ -21,17 +23,18 @@ describe Handlers::MessageHandler do
     it 'inserts a Message' do
       returned_id = subject.handle(event)
 
-      message = Message.first(id: returned_id)
-      message.id.must_equal(returned_id)
-      message.channel_id.must_equal('C123')
-      message.user_id.must_equal('U123')
-      message.text.must_equal('Hello')
-      message.timestamp.must_equal(DateTime.parse('2019-08-03T14:11:39-04:00'))
+      message = messages.where(id: returned_id).first
+      _(message[:id]).must_equal(returned_id)
+      _(message[:channel_id]).must_equal('C123')
+      _(message[:user_id]).must_equal('U123')
+      _(message[:text]).must_equal('Hello')
+      _(message[:timestamp].utc.iso8601).must_equal(
+        Time.new(2019, 8, 3, 18, 11, 39.55599).utc.iso8601)
     end
 
     it 'upserts a User' do
       subject.handle(event)
-      User.first(id: 'U123').wont_equal(nil)
+      _(users.where(id: 'U123').count).must_equal(1)
     end
   end
 end

--- a/test/functional/handlers/message_handler_test.rb
+++ b/test/functional/handlers/message_handler_test.rb
@@ -40,11 +40,12 @@ describe Handlers::MessageHandler do
 
     describe 'when the User has opted-out' do
       let(:user_id) { 'UOPTOUT' }
+
       before do
         users.insert(id: user_id, opted_out: true)
       end
 
-      it 'stores a message with the text blanked out' do
+      it 'stores a message with the text redacted' do
         returned_id = subject.handle(event)
 
         message = messages.where(id: returned_id).first

--- a/test/functional/handlers/message_handler_test.rb
+++ b/test/functional/handlers/message_handler_test.rb
@@ -6,12 +6,13 @@ describe Handlers::MessageHandler do
   let(:users) { Sequel::Model.db[:users] }
 
   describe '#handle' do
+    let(:user_id) { 'U123' }
     let(:event) { {
       "client_msg_id" => "a uuid",
       "suppress_notification":false,
       "type" => "message",
       "text" => "Hello",
-      "user" => "U123",
+      "user" => user_id,
       "team" => "T123",
       "user_team" => "T123",
       "source_team" => "T123",
@@ -26,7 +27,7 @@ describe Handlers::MessageHandler do
       message = messages.where(id: returned_id).first
       _(message[:id]).must_equal(returned_id)
       _(message[:channel_id]).must_equal('C123')
-      _(message[:user_id]).must_equal('U123')
+      _(message[:user_id]).must_equal(user_id)
       _(message[:text]).must_equal('Hello')
       _(message[:timestamp].utc.iso8601).must_equal(
         Time.new(2019, 8, 3, 18, 11, 39.55599).utc.iso8601)
@@ -34,7 +35,26 @@ describe Handlers::MessageHandler do
 
     it 'upserts a User' do
       subject.handle(event)
-      _(users.where(id: 'U123').count).must_equal(1)
+      _(users.where(id: user_id).count).must_equal(1)
+    end
+
+    describe 'when the User has opted-out' do
+      let(:user_id) { 'UOPTOUT' }
+      before do
+        users.insert(id: user_id, opted_out: true)
+      end
+
+      it 'stores a message with the text blanked out' do
+        returned_id = subject.handle(event)
+
+        message = messages.where(id: returned_id).first
+        _(message[:id]).must_equal(returned_id)
+        _(message[:channel_id]).must_equal('C123')
+        _(message[:user_id]).must_equal(user_id)
+        _(message[:text]).must_equal('[redacted]')
+        _(message[:timestamp].utc.iso8601).must_equal(
+          Time.new(2019, 8, 3, 18, 11, 39.55599).utc.iso8601)
+      end
     end
   end
 end

--- a/test/functional/handlers/user_handler_test.rb
+++ b/test/functional/handlers/user_handler_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 describe Handlers::UserHandler do
   subject { Handlers::UserHandler.new }
+  let(:table) { Sequel::Model.db[:users] }
 
   describe '#handle' do
     let(:my_name) { 'Zac' }
@@ -16,10 +17,10 @@ describe Handlers::UserHandler do
     } }
 
     describe 'when the user has never been seen before' do
-      it 'inserts a new User and returns its id' do
+      it 'inserts a new User and returns it' do
         returned_id = subject.handle(event)
-        User.first(id: id).name.must_equal(my_name)
-        returned_id.must_equal(id)
+        _(table.where(id: id).first[:name]).must_equal(my_name)
+        _(returned_id).must_equal(id)
       end
     end
 
@@ -34,10 +35,10 @@ describe Handlers::UserHandler do
       end
 
       it 'updates the existing User' do
-        User.first(id: id).name.must_equal('Caz')
+        _(table.where(id: id).first[:name]).must_equal('Caz')
 
         subject.handle(event)
-        User.first(id: id).name.must_equal(my_name)
+        _(table.where(id: id).first[:name]).must_equal(my_name)
       end
     end
 
@@ -46,10 +47,8 @@ describe Handlers::UserHandler do
 
       it 'touches the User record and returns its id' do
         returned_id = subject.handle(event)
-        user = User.first(id: id)
-        user.id.must_equal(id)
-        user.name.must_equal(my_name)
         returned_id.must_equal(id)
+        _(table.where(id: id).count).must_equal(1)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,14 +9,17 @@ require 'minitest/spec'
 require 'mocha/mini_test'
 require 'minitest/autorun'
 require 'database_cleaner'
+require 'database_cleaner-sequel'
+
+DatabaseCleaner[:sequel].db = Tech404logs.db
 
 class FunctionalSpec < MiniTest::Spec
   before do
-    DatabaseCleaner.start
+    DatabaseCleaner[:sequel].start
   end
 
   after do
-    DatabaseCleaner.clean
+    DatabaseCleaner[:sequel].clean
   end
 end
 


### PR DESCRIPTION
Adds a flag to opt a user out of being archived. Their messages will be replaced with "[redacted]" and their user data (name, avatar, etc) will not be updated moving forward.

A separate PR will follow this one to redact historic data.

Partially resolves
- #45 
- #46 